### PR TITLE
Revert "use sticky sessions for GQL requests to sentries (#1042)"

### DIFF
--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -49,7 +49,6 @@ metadata:
   name: {{ template "fuel-core.name" . }}-lb-service
 spec:
   type: LoadBalancer
-  sessionAffinity: ClientIP
   selector:
     app: {{ .Values.app.selector_name }}
   ports:


### PR DESCRIPTION
This reverts commit 01e9d8937cb2685d4ae30710a057a99f091358d1.

https://alpha.fuel.network/ecosystem

